### PR TITLE
Replaced static query var 'company' with dynamic $this->slug

### DIFF
--- a/wp-job-manager-companies.php
+++ b/wp-job-manager-companies.php
@@ -97,7 +97,7 @@ class Astoundify_Job_Manager_Companies {
 	 * @return array $vars The modified array of query variables.
 	 */
 	public function query_vars( $vars ) {
-		$vars[] = 'company';
+		$vars[] = $this->slug;
 
 		return $vars;
 	}
@@ -134,7 +134,7 @@ class Astoundify_Job_Manager_Companies {
 	public function template_loader() {
 		global $wp_query;
 
-		if ( ! get_query_var( 'company' ) )
+		if ( ! get_query_var( $this->slug ) )
 			return;
 
 		if ( 0 == $wp_query->found_posts )
@@ -304,10 +304,10 @@ class Astoundify_Job_Manager_Companies {
 	function page_title( $title, $sep ) {
 		global $paged, $page;
 
-		if ( ! get_query_var( 'company' ) )
+		if ( ! get_query_var( $this->slug ) )
 			return $title;
 
-		$company = urldecode( get_query_var( 'company' ) );
+		$company = urldecode( get_query_var( $this->slug ) );
 
 		$title = get_bloginfo( 'name' );
 


### PR DESCRIPTION
The problem with changing the slug is that the query var remains the same. Let's say I change it to 'organization' then my links become http://mydomain.de/organization/Orga+Name and all the static `get_query_var( 'company' )` functions return empty. Thus the correct template is not loaded. 
`( ! get_query_var( 'organization' ) )` isn't working as well since it hasn't been registered as a queriable var.

I think a clever rewrite rule should be able to bend all requests from the custom slug to a static query var. My knowledge of the Rewrite API is too limited so instead I replaced the static 'company' query var with the slug to resolve the issue. 
